### PR TITLE
シークレットyml用のシンボリックリンクを追加

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -25,7 +25,10 @@ set :unicorn_pid, -> { "#{shared_path}/tmp/pids/unicorn.pid" }
 # Unicornの設定ファイルの場所
 set :unicorn_config_path, -> { "#{current_path}/config/unicorn.rb" }
 set :keep_releases, 5
+# secrets.yml用のシンボリックリンクを追加
+set :linked_files, %w{ config/secrets.yml }
 
+# 元々記述されていた after 「'deploy:publishing', 'deploy:restart'」以下を削除して、次のように書き換え
 # デプロイ処理が終わった後、Unicornを再起動するための記述
 after 'deploy:publishing', 'deploy:restart'
 namespace :deploy do


### PR DESCRIPTION
# what
　記述不足のシンボリックリンクを追加
# why
　記述漏れのため