### PR TITLE
商品購入確認ページ

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -28,3 +28,5 @@
 @import "devise/address";
 @import "devise/finising";
 @import "devise/paying";
+
+@import "buying/buying";

--- a/app/assets/stylesheets/buying/buying.scss
+++ b/app/assets/stylesheets/buying/buying.scss
@@ -1,0 +1,108 @@
+.buying{
+  width: 700px;
+  height: 750px;
+  background-color: #FFFFFF;
+  margin: 0 auto;
+  .buyingPadding{
+    box-sizing: border-box;
+    padding: 24px 87.5px 35px;
+    border-bottom: solid 1px $backColor;
+  }
+  &__top{
+    @include mercariTitle(65px);
+  }
+  &__main{
+    width: 320px;
+    margin: 0 auto;
+    &__product{
+      display: flex;
+      &__image{
+        margin-right: 15px;
+        & img{
+          width: 64px;
+        }
+      }
+      &__title{
+        @include font_data($mercariBlack, 15px, bold);
+      }
+    }
+    &__cost{
+      display: flex;
+      justify-content: center;
+      height: 33px;
+      &__num{
+        @include font_data($mercariBlack,18px,bold);
+        margin-right:15px;
+        line-height: 33px;
+      }
+      &__way{
+        @include font_data($mercariBlack, 14px);
+        line-height: 33px;
+      }
+    }
+    &__points{
+      @include buttonParent($width: 320px);
+      margin-top: 20px;
+      background-color: rgb(194, 194, 194);
+      color: $mercariBlack;
+    }
+    &__allCost{
+      display: flex;
+      justify-content: space-between;
+      height: 60px;
+      &__label{
+        @include font_data($mercariBlack, 16px, bold);
+        line-height: 60px;
+      }
+      &__num{
+        @include font_data($mercariBlack, 28px, bold);
+        line-height: 60px;
+      }
+    }
+    &__button{
+      @include buttonParent($width: 320px);
+      background-color: $mercariRed;
+      color: #FFFFFF;
+    }
+  }
+  &__address{
+    width: 320px;
+    margin: 0 auto;
+    @include font_data($mercariBlack,14px);
+    &__label{
+      @include font_data($mercariBlack,14px,bold);
+    }
+    &__num{
+      @include font_data($mercariBlack,10px,bold);
+    }
+    &__change{
+      margin-top: 10px;
+      @include mercariLink;
+      text-align: right;
+    }
+  }
+  &__paying{
+    width: 320px;
+    margin: 0 auto;
+    @include font_data($mercariBlack,14px);
+    &__label{
+      @include font_data($mercariBlack,14px,bold);
+    }
+    &__image{
+      & img{
+        width: 30px;
+      }
+    }
+    &__num{
+      @include font_data($mercariBlack,10px,bold);
+    }
+    &__term{
+      @include font_data($mercariBlack,12px);
+    }
+    &__change{
+      margin-top: 10px;
+      @include mercariLink;
+      text-align: right;
+    }
+  }
+}

--- a/app/assets/stylesheets/mixin/j/_j.scss
+++ b/app/assets/stylesheets/mixin/j/_j.scss
@@ -88,8 +88,8 @@
 }
 
 // メルカリ入力フォームのタイトル
-@mixin mercariTitle{
+@mixin mercariTitle($height: 95px){
   @include font_data($mercariBlack,22px,bold);
-  @include text_center(95px,center);
+  @include text_center($height, center);
   border-bottom: solid 1px $backColor;
 }

--- a/app/controllers/buyings_controller.rb
+++ b/app/controllers/buyings_controller.rb
@@ -1,0 +1,5 @@
+class BuyingsController < ApplicationController
+  layout "simple"
+  def index
+  end
+end

--- a/app/views/buyings/index.html.haml
+++ b/app/views/buyings/index.html.haml
@@ -1,0 +1,52 @@
+.buying
+  .buying__top
+    購入内容の確認
+  .buyingPadding
+    .buying__main
+      .buying__main__product
+        .buying__main__product__image
+          = image_tag("https://static.mercdn.net/thumb/photos/m59992978524_1.jpg?1561704174")
+        .buying__main__product__title
+          ユーロ96予選 イタリア ナイキ 10番
+      .buying__main__cost
+        .buying__main__cost__num
+          ¥2,200
+        .buying__main__cost__way
+          送料込み
+      .buying__main__points
+        ポイントはありません
+      .buying__main__allCost
+        .buying__main__allCost__label
+          支払い金額
+        .buying__main__allCost__num
+          ¥2,200
+      .buying__main__button
+        購入する
+  .buyingPadding
+    .buying__address
+      .buying__address__label
+        配送先
+      .buying__address__num
+        〒150−0041
+      .buying__address__text
+        東京都渋谷区神南1丁目12−16アジアビル8F
+      .buying__address__name
+        株式会社div
+      .buying__address__change
+        = link_to do
+          変更する
+          = fa_icon "chevron-right"
+  .buyingPadding
+    .buying__paying
+      .buying__paying__label
+        支払い方法
+      .buying__paying__num
+        **********0909
+      .buying__paying__term
+        08/23
+      .buying__paying__image
+        = image_tag("https://www-mercari-jp.akamaized.net/assets/img/card/master-card.svg?2394192159")
+      .buying__paying__change
+        = link_to do
+          変更する
+          = fa_icon "chevron-right"

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -2,29 +2,29 @@
   .contents__header__inner
     .contents__header__inner__top
       = link_to root_path do
-        = image_tag("//www-mercari-jp.akamaized.net/assets/img/common/common/logo.svg?575670517", width: "134", height: "36") 
-      .contents__header__inner__top__form         
-        %input.contents__header__inner__top__form__input{placeholder: "何かお探しですか？", type: "serch"}/ 
-        =fa_icon "search" , class: "contents__header__inner__top__form__icon"        
+        = image_tag("//www-mercari-jp.akamaized.net/assets/img/common/common/logo.svg?575670517", width: "134", height: "36")
+      .contents__header__inner__top__form
+        %input.contents__header__inner__top__form__input{placeholder: "何かお探しですか？", type: "serch"}/
+        =fa_icon "search" , class: "contents__header__inner__top__form__icon"
     .contents__header__inner__down
       .contents__header__inner__down__left
         .contents__header__inner__down__left__category
-          = link_to root_path do
+          = link_to product_buyings_path(1) do
             =fa_icon "list" , class: "contents__header__inner__down__left__category__icon"
             カテゴリーから探す
         .contents__header__inner__down__left__tag
           = link_to user_session_path , method: :post do
             =fa_icon "tag" , class: "contents__header__inner__down__left__tag__icon"
-            ブランドから探す  
+            ブランドから探す
       .contents__header__inner__down__right
         .contents__header__inner__down__right__notice
           = link_to destroy_user_session_path , method: :delete do
             =fa_icon "bell" , class: "contents__header__inner__down__right__notice__icon"
-            お知らせ  
+            お知らせ
         .contents__header__inner__down__right__todo
           = link_to new_user_registration_path do
             =fa_icon "check" , class: "contents__header__inner__down__right__todo__icon"
-            やることリスト  
+            やることリスト
         .contents__header__inner__down__right__mypage
           -if user_signed_in?
             = link_to user_path(current_user) do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,9 @@
 Rails.application.routes.draw do
   devise_for :users, controllers: { sessions: 'users/sessions', omniauth_callbacks: 'users/omniauth_callbacks', registrations: 'users/registrations' }
   root "products#index"
-  resources :products
+  resources :products do
+    resources :buyings, only: :index
+  end
   resources :users, only: [:show] do
     resources :identifications, only: [:index]
   end


### PR DESCRIPTION
# What
商品購入確認ページを仮置する
# Why
ユーザーに購入する商品の最終確認を行わせることで購入ミスを防ぐ。
また商品購入確認ページを予め作成することで、商品購入に関する処理を作成した際に確認が容易い