### PR TITLE
errorを修正

### DIFF
--- a/app/assets/javascripts/products/cost.js
+++ b/app/assets/javascripts/products/cost.js
@@ -4,9 +4,6 @@ $(function(){
   // 手数料と利益の計算を行う
   cost.on("keyup", function(){
     var input = $(this).val();
-    if(!input.match(/^([1-9]\d*|0)$/)){
-      $(this).val("");
-    }
     if(input >= 300 && input <= 9999999){
       $(".main__product__price__h3__cost").html(`￥${(Math.round(input * 0.1)).toLocaleString()}`);
       $(".main__product__price__h4__profit").html(`￥${(Math.round(input * 0.9)).toLocaleString()}`);

--- a/app/assets/stylesheets/category/show.scss
+++ b/app/assets/stylesheets/category/show.scss
@@ -9,6 +9,11 @@
   &__Products{
     display:flex;
     flex-flow: row wrap;
+    & .render__wrap{
+      & a{
+        @include reset_a-tag(black);
+      }
+    }
   }
   &__box{
     width: 80%;

--- a/app/assets/stylesheets/products/_new.scss
+++ b/app/assets/stylesheets/products/_new.scss
@@ -353,6 +353,14 @@
         font-size: 13px;
         margin-bottom: 10px;
         font-weight: 500;
+        &::-webkit-inner-spin-button{
+          -webkit-appearance: none;
+          margin: 0;
+        }
+        &::-webkit-outer-spin-button{
+          -webkit-appearance: none;
+          margin: 0;
+        }
       }
       &__h3 {
         padding: 24px 0;

--- a/app/controllers/payings_controller.rb
+++ b/app/controllers/payings_controller.rb
@@ -1,6 +1,7 @@
 class PayingsController < TelphonesController
   require "payjp"
   layout "simple"
+  layout "devise", only: :new
   def new
     @active = ["is-active","is-active","is-active",""]
     @year = [*19..30]

--- a/app/views/products/edit.html.haml
+++ b/app/views/products/edit.html.haml
@@ -109,7 +109,7 @@
         .main__product__price__h2
           価格
           %span 必須
-          = f.telephone_field :price, placeholder:"例) 300", class: "main__product__price__h2-choice", value: @product.price, maxlength: 7
+          = f.number_field :price, placeholder:"例) 300", class: "main__product__price__h2-choice", value: @product.price, min: "300", max: "9999999"
           %p ￥
         .main__product__price__h3
           .main__product__price__h3__info

--- a/app/views/products/new.html.haml
+++ b/app/views/products/new.html.haml
@@ -105,7 +105,7 @@
         .main__product__price__h2
           価格
           %span 必須
-          = f.telephone_field :price, placeholder:"例) 300", class: "main__product__price__h2-choice", value: @product.price, maxlength: 7
+          = f.number_field :price, placeholder:"例) 300", class: "main__product__price__h2-choice", value: @product.price, min: "300", max: "9999999"
           %p ￥
         .main__product__price__h3
           .main__product__price__h3__info


### PR DESCRIPTION
# What
1. ユーザー登録時にクレジットカード登録ページでプログレスバーを表示
2. 出品時のコスト入力欄をnumberフィールドに変更
3. カテゴリー検索時の商品のcssを変更
# Why
1. 表示されていなかったため
2. javascriptで制御していたが全角文字列入力時にエラーが発生したため
3. 下線が含まれていたため
## 1
[![Image from Gyazo](https://i.gyazo.com/e51a5f34fbaf7f73093533a01e453018.png)](https://gyazo.com/e51a5f34fbaf7f73093533a01e453018)
## 2
[![Image from Gyazo](https://i.gyazo.com/3e460e2ddb86afe9b72056a7004613d3.gif)](https://gyazo.com/3e460e2ddb86afe9b72056a7004613d3)
## 3
[![Image from Gyazo](https://i.gyazo.com/3c2efe27808a6cd2febb0a2634fdfdfe.png)](https://gyazo.com/3c2efe27808a6cd2febb0a2634fdfdfe)